### PR TITLE
Fix typo in project selection function

### DIFF
--- a/scripts/utils/project.sh
+++ b/scripts/utils/project.sh
@@ -8,7 +8,7 @@ check_project_name() {
     PROJECT_NAME=$1
 
     if [[ -z "${PROJECT_NAME}" ]]; then
-        select_porject
+        select_project
     fi
 }
 
@@ -260,7 +260,7 @@ exec_project_deploy_container() {
     fi
 }
 
-select_porject() {
+select_project() {
     TARGET_NAMESPACE=$1
 
     projects=($(list_projects))


### PR DESCRIPTION
## Summary
- fix function name `select_porject` typo to `select_project`
- update call site in `check_project_name`

## Testing
- `bash -c 'source scripts/utils/project.sh; check_project_name ""' <<< "1"`

------
https://chatgpt.com/codex/tasks/task_e_68464a24197883278d2f335de584786e