### PR TITLE
feat: support loading stage env from HashiCorp Vault in pipeline

### DIFF
--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache curl jq

--- a/dockerfiles/tools/build.sh
+++ b/dockerfiles/tools/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Build tools image ..."
+docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t r82wei/tools:1.0.0 .

--- a/dockerfiles/tools/build.sh
+++ b/dockerfiles/tools/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Build tools image ..."
-docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t r82wei/tools:1.0.0 .
+docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t r82wei/kde-cli/tools:1.0.0 .

--- a/dockerfiles/tools/build.sh
+++ b/dockerfiles/tools/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+TOOLS_VERSION=1.0.0
+DATE=$(date +%Y%m%d%H%M%S)
+TARGET_ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+
 echo "Build tools image ..."
-docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t r82wei/kde-cli/tools:1.0.0 .
+docker buildx build --load -f Dockerfile -t r82wei/kde-cli/tools:${TOOLS_VERSION}-${TARGET_ARCH}-${DATE} .

--- a/dockerfiles/tools/release.sh
+++ b/dockerfiles/tools/release.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOOLS_VERSION=1.0.0
+
+echo "Release tools ${TOOLS_VERSION} image ..."
+docker buildx build --no-cache --platform linux/amd64,linux/arm64 --push -f Dockerfile -t r82wei/kde-cli/tools:${TOOLS_VERSION} .
+docker buildx build --platform linux/amd64,linux/arm64 --push -f Dockerfile -t r82wei/kde-cli/tools:latest .

--- a/docs/core/cicd-pipeline.md
+++ b/docs/core/cicd-pipeline.md
@@ -51,6 +51,12 @@
 | `KDE_PIPELINE_STAGE_[階段名稱]_MANUAL_ONLY` | 只能透過 --manual 參數手動觸發 | `false` | `KDE_PIPELINE_STAGE_lint_MANUAL_ONLY=true` |
 | `KDE_PIPELINE_STAGE_[階段名稱]_ALLOW_FAILURE` | 允許該階段失敗但不影響後續階段 | `false` | `KDE_PIPELINE_STAGE_lint_ALLOW_FAILURE=true` |
 | `KDE_PIPELINE_STAGE_[階段名稱]_PAUSE` | 階段執行完畢後暫停，等待使用者確認是否繼續 | `false` | `KDE_PIPELINE_STAGE_preview_PAUSE=true` |
+| `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_ENABLED` | 啟用該階段從 Vault 載入 secrets | `false` | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_ENABLED=true` |
+| `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_ADDR` | Vault API 位址 | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_ADDR=https://vault.example.com` |
+| `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_TOKEN` | Vault Token（建議放 `.env`） | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_TOKEN=s.xxxxx` |
+| `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_CACERT` | 自簽 CA 憑證路徑 | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_CACERT=/path/to/ca.pem` |
+| `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_MAP` | Secret mapping（`ENV=path#key`，逗號分隔） | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_MAP=DB_PASS=kv/data/prod/app#db_password` |
+| `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_STRICT` | 注入失敗時是否中止階段 | `true` | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_STRICT=false` |
 | `KDE_PIPELINE_FAIL_FAST` | 任何階段失敗時立即停止整個 pipeline | `true` | `KDE_PIPELINE_FAIL_FAST=false` |
 | `KDE_MOUNT_[自定義名稱]` | 掛載所有階段共用的檔案或資料夾 | 無 | `KDE_MOUNT_SSH=${}/.ssh:${PROJECT_PATH}/.ssh` |
 
@@ -344,6 +350,39 @@ kde proj pipeline myapp
 # - security-scan 失敗 → 顯示警告，繼續執行 deploy
 # - build 失敗 → Pipeline 立即停止（預設 Fail Fast 行為）
 ```
+
+### 範例 7：Deploy 階段從 HashiCorp Vault 載入敏感資訊
+
+```bash
+# project.env
+KDE_PIPELINE_STAGES="build,deploy"
+
+KDE_PIPELINE_STAGE_build_SCRIPT=build.sh
+KDE_PIPELINE_STAGE_build_IMAGE=node:24
+
+KDE_PIPELINE_STAGE_deploy_SCRIPT=deploy.sh
+KDE_PIPELINE_STAGE_deploy_IMAGE=r82wei/deploy-env:1.0.0
+
+# 啟用 Vault 注入（deploy 階段）
+KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_ENABLED=true
+KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_ADDR=https://vault.example.com
+KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_MAP=DB_PASS=kv/data/prod/myapp#db_password,API_KEY=kv/data/prod/myapp#api_key
+
+# (optional) 自簽 CA
+KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_CACERT=/path/to/ca.pem
+
+# (optional) 失敗不中斷
+# KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_STRICT=false
+```
+
+```bash
+# .env（避免 token 進版控）
+KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_TOKEN=s.xxxxx
+```
+
+說明：
+- 僅注入 `ENV_FROM_VAULT_MAP` 指定的變數，降低洩漏風險。
+- 注入後變數會寫入 `.pipeline.env`，並在該階段腳本執行前自動載入。
 
 ## Best Practice
 - 使用專案名稱作為 K8S 部署目標 namespace

--- a/docs/core/cicd-pipeline.md
+++ b/docs/core/cicd-pipeline.md
@@ -57,6 +57,7 @@
 | `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_CACERT` | 自簽 CA 憑證路徑 | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_CACERT=/path/to/ca.pem` |
 | `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_MAP` | Secret mapping（`ENV=path#key`，逗號分隔） | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_MAP=DB_PASS=kv/data/prod/app#db_password` |
 | `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_STRICT` | 注入失敗時是否中止階段 | `true` | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_STRICT=false` |
+| `KDE_TOOLS_IMAGE` | tools 容器映像（Vault JSON 解析用，啟動即用完即刪） | `r82wei/tools:1.0.0` | `KDE_TOOLS_IMAGE=r82wei/tools:1.0.0` |
 | `KDE_PIPELINE_FAIL_FAST` | 任何階段失敗時立即停止整個 pipeline | `true` | `KDE_PIPELINE_FAIL_FAST=false` |
 | `KDE_MOUNT_[自定義名稱]` | 掛載所有階段共用的檔案或資料夾 | 無 | `KDE_MOUNT_SSH=${}/.ssh:${PROJECT_PATH}/.ssh` |
 
@@ -383,6 +384,7 @@ KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_TOKEN=s.xxxxx
 說明：
 - 僅注入 `ENV_FROM_VAULT_MAP` 指定的變數，降低洩漏風險。
 - 注入後變數會寫入 `.pipeline.env`，並在該階段腳本執行前自動載入。
+- JSON 解析透過 `KDE_TOOLS_IMAGE` 啟動一次性 container 執行 `jq`（`docker run -i --rm`），解析完即關閉容器。
 
 ## Best Practice
 - 使用專案名稱作為 K8S 部署目標 namespace

--- a/docs/core/cicd-pipeline.md
+++ b/docs/core/cicd-pipeline.md
@@ -57,7 +57,7 @@
 | `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_CACERT` | 自簽 CA 憑證路徑 | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_CACERT=/path/to/ca.pem` |
 | `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_MAP` | Secret mapping（`ENV=path#key`，逗號分隔） | 無 | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_MAP=DB_PASS=kv/data/prod/app#db_password` |
 | `KDE_PIPELINE_STAGE_[階段名稱]_ENV_FROM_VAULT_STRICT` | 注入失敗時是否中止階段 | `true` | `KDE_PIPELINE_STAGE_deploy_ENV_FROM_VAULT_STRICT=false` |
-| `KDE_TOOLS_IMAGE` | tools 容器映像（Vault JSON 解析用，啟動即用完即刪） | `r82wei/tools:1.0.0` | `KDE_TOOLS_IMAGE=r82wei/tools:1.0.0` |
+| `KDE_TOOLS_IMAGE` | tools 容器映像（Vault JSON 解析用，啟動即用完即刪） | `r82wei/kde-cli/tools:1.0.0` | `KDE_TOOLS_IMAGE=r82wei/kde-cli/tools:1.0.0` |
 | `KDE_PIPELINE_FAIL_FAST` | 任何階段失敗時立即停止整個 pipeline | `true` | `KDE_PIPELINE_FAIL_FAST=false` |
 | `KDE_MOUNT_[自定義名稱]` | 掛載所有階段共用的檔案或資料夾 | 無 | `KDE_MOUNT_SSH=${}/.ssh:${PROJECT_PATH}/.ssh` |
 

--- a/scripts/utils/pipeline.sh
+++ b/scripts/utils/pipeline.sh
@@ -257,7 +257,7 @@ filter_pipeline_stages() {
     echo "${FILTERED_STAGES}" | xargs
 }
 
-# 從 HashiCorp Vault 取得單一 secret value
+# 從 HashiCorp Vault 取得單一 secret value（純 Bash + curl）
 # 參數：
 #   $1 - Vault 位址
 #   $2 - Vault Token
@@ -272,57 +272,41 @@ fetch_vault_secret_value() {
     local SECRET_KEY="$4"
     local VAULT_CACERT="$5"
 
-    VAULT_ADDR="${VAULT_ADDR}" \
-    VAULT_TOKEN="${VAULT_TOKEN}" \
-    SECRET_PATH="${SECRET_PATH}" \
-    SECRET_KEY="${SECRET_KEY}" \
-    VAULT_CACERT="${VAULT_CACERT}" \
-    python3 - <<'PY'
-import json
-import os
-import ssl
-import sys
-import urllib.request
+    if [[ -z "${VAULT_ADDR}" || -z "${VAULT_TOKEN}" || -z "${SECRET_PATH}" || -z "${SECRET_KEY}" ]]; then
+        return 2
+    fi
 
-addr = os.environ.get("VAULT_ADDR", "").rstrip("/")
-token = os.environ.get("VAULT_TOKEN", "")
-secret_path = os.environ.get("SECRET_PATH", "")
-secret_key = os.environ.get("SECRET_KEY", "")
-cacert = os.environ.get("VAULT_CACERT", "")
+    local URL="${VAULT_ADDR%/}/v1/${SECRET_PATH#/}"
+    local CURL_ARGS=(--silent --show-error --fail --max-time 15 -H "X-Vault-Token: ${VAULT_TOKEN}")
 
-if not addr or not token or not secret_path or not secret_key:
-    sys.exit(2)
+    if [[ -n "${VAULT_CACERT}" ]]; then
+        CURL_ARGS+=(--cacert "${VAULT_CACERT}")
+    fi
 
-url = f"{addr}/v1/{secret_path.lstrip('/')}"
-req = urllib.request.Request(url)
-req.add_header("X-Vault-Token", token)
+    local RESPONSE
+    if ! RESPONSE=$(curl "${CURL_ARGS[@]}" "${URL}"); then
+        return 3
+    fi
 
-ctx = None
-if cacert:
-    ctx = ssl.create_default_context(cafile=cacert)
+    # 優先使用 jq 解析（支援 KV v2: .data.data[key] 與 KV v1: .data[key]）
+    if command -v jq >/dev/null 2>&1; then
+        local VALUE
+        if VALUE=$(echo "${RESPONSE}" | jq -er --arg key "${SECRET_KEY}" '.data.data[$key] // .data[$key]'); then
+            printf '%s' "${VALUE}"
+            return 0
+        fi
+        return 4
+    fi
 
-try:
-    with urllib.request.urlopen(req, context=ctx, timeout=15) as resp:
-        payload = json.loads(resp.read().decode("utf-8"))
-except Exception:
-    sys.exit(3)
+    # 無 jq 時的降級解析（僅支援簡單 JSON 字串值）
+    local VALUE
+    VALUE=$(echo "${RESPONSE}" | tr -d '\n' | sed -nE "s/.*\"${SECRET_KEY}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\".*/\1/p")
+    if [[ -n "${VALUE}" ]]; then
+        printf '%s' "${VALUE}"
+        return 0
+    fi
 
-# 支援 KV v2（data.data）與 KV v1（data）
-obj = payload.get("data", {})
-if isinstance(obj, dict) and isinstance(obj.get("data"), dict):
-    data = obj.get("data", {})
-else:
-    data = obj
-
-if secret_key not in data:
-    sys.exit(4)
-
-value = data.get(secret_key)
-if value is None:
-    value = ""
-
-print(str(value), end="")
-PY
+    return 4
 }
 
 # 將 Vault secrets 注入到 .pipeline.env（階段級）

--- a/scripts/utils/pipeline.sh
+++ b/scripts/utils/pipeline.sh
@@ -288,25 +288,15 @@ fetch_vault_secret_value() {
         return 3
     fi
 
-    # 優先使用 jq 解析（支援 KV v2: .data.data[key] 與 KV v1: .data[key]）
-    if command -v jq >/dev/null 2>&1; then
-        local VALUE
-        if VALUE=$(echo "${RESPONSE}" | jq -er --arg key "${SECRET_KEY}" '.data.data[$key] // .data[$key]'); then
-            printf '%s' "${VALUE}"
-            return 0
-        fi
+    # 使用 tools image 啟動一次性容器解析 JSON，結束即刪除（docker run --rm -i）
+    local TOOLS_IMAGE="${KDE_TOOLS_IMAGE:-r82wei/tools:1.0.0}"
+    local VALUE
+    if ! VALUE=$(printf '%s' "${RESPONSE}" | docker run --rm -i -e SECRET_KEY="${SECRET_KEY}" "${TOOLS_IMAGE}" jq -er --arg key "${SECRET_KEY}" '.data.data[$key] // .data[$key]' 2>/dev/null); then
         return 4
     fi
 
-    # 無 jq 時的降級解析（僅支援簡單 JSON 字串值）
-    local VALUE
-    VALUE=$(echo "${RESPONSE}" | tr -d '\n' | sed -nE "s/.*\"${SECRET_KEY}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\".*/\1/p")
-    if [[ -n "${VALUE}" ]]; then
-        printf '%s' "${VALUE}"
-        return 0
-    fi
-
-    return 4
+    printf '%s' "${VALUE}"
+    return 0
 }
 
 # 將 Vault secrets 注入到 .pipeline.env（階段級）

--- a/scripts/utils/pipeline.sh
+++ b/scripts/utils/pipeline.sh
@@ -257,6 +257,163 @@ filter_pipeline_stages() {
     echo "${FILTERED_STAGES}" | xargs
 }
 
+# 從 HashiCorp Vault 取得單一 secret value
+# 參數：
+#   $1 - Vault 位址
+#   $2 - Vault Token
+#   $3 - Secret Path
+#   $4 - Secret Key
+#   $5 - CA 憑證路徑（可選）
+# 返回：stdout 輸出 secret value
+fetch_vault_secret_value() {
+    local VAULT_ADDR="$1"
+    local VAULT_TOKEN="$2"
+    local SECRET_PATH="$3"
+    local SECRET_KEY="$4"
+    local VAULT_CACERT="$5"
+
+    VAULT_ADDR="${VAULT_ADDR}" \
+    VAULT_TOKEN="${VAULT_TOKEN}" \
+    SECRET_PATH="${SECRET_PATH}" \
+    SECRET_KEY="${SECRET_KEY}" \
+    VAULT_CACERT="${VAULT_CACERT}" \
+    python3 - <<'PY'
+import json
+import os
+import ssl
+import sys
+import urllib.request
+
+addr = os.environ.get("VAULT_ADDR", "").rstrip("/")
+token = os.environ.get("VAULT_TOKEN", "")
+secret_path = os.environ.get("SECRET_PATH", "")
+secret_key = os.environ.get("SECRET_KEY", "")
+cacert = os.environ.get("VAULT_CACERT", "")
+
+if not addr or not token or not secret_path or not secret_key:
+    sys.exit(2)
+
+url = f"{addr}/v1/{secret_path.lstrip('/')}"
+req = urllib.request.Request(url)
+req.add_header("X-Vault-Token", token)
+
+ctx = None
+if cacert:
+    ctx = ssl.create_default_context(cafile=cacert)
+
+try:
+    with urllib.request.urlopen(req, context=ctx, timeout=15) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+except Exception:
+    sys.exit(3)
+
+# 支援 KV v2（data.data）與 KV v1（data）
+obj = payload.get("data", {})
+if isinstance(obj, dict) and isinstance(obj.get("data"), dict):
+    data = obj.get("data", {})
+else:
+    data = obj
+
+if secret_key not in data:
+    sys.exit(4)
+
+value = data.get(secret_key)
+if value is None:
+    value = ""
+
+print(str(value), end="")
+PY
+}
+
+# 將 Vault secrets 注入到 .pipeline.env（階段級）
+# 參數：
+#   $1 - 階段名稱
+#   $2 - 專案路徑
+# 返回：0 成功，非 0 失敗
+inject_stage_env_from_vault() {
+    local STAGE="$1"
+    local PROJECT_PATH="$2"
+    local STAGE_VAR=$(echo "${STAGE}" | tr '-' '_')
+
+    local ENABLED_VAR="KDE_PIPELINE_STAGE_${STAGE_VAR}_ENV_FROM_VAULT_ENABLED"
+    local ADDR_VAR="KDE_PIPELINE_STAGE_${STAGE_VAR}_ENV_FROM_VAULT_ADDR"
+    local TOKEN_VAR="KDE_PIPELINE_STAGE_${STAGE_VAR}_ENV_FROM_VAULT_TOKEN"
+    local CACERT_VAR="KDE_PIPELINE_STAGE_${STAGE_VAR}_ENV_FROM_VAULT_CACERT"
+    local MAP_VAR="KDE_PIPELINE_STAGE_${STAGE_VAR}_ENV_FROM_VAULT_MAP"
+    local STRICT_VAR="KDE_PIPELINE_STAGE_${STAGE_VAR}_ENV_FROM_VAULT_STRICT"
+
+    local ENABLED="${!ENABLED_VAR}"
+    local VAULT_ADDR="${!ADDR_VAR}"
+    local VAULT_TOKEN="${!TOKEN_VAR}"
+    local VAULT_CACERT="${!CACERT_VAR}"
+    local VAULT_MAP="${!MAP_VAR}"
+    local STRICT_MODE="${!STRICT_VAR}"
+    local PIPELINE_ENV_FILE="${PROJECT_PATH}/.pipeline.env"
+
+    # 若未明確啟用，直接跳過
+    if [[ "${ENABLED}" != "true" ]]; then
+        return 0
+    fi
+
+    # strict 預設啟用
+    if [[ -z "${STRICT_MODE}" ]]; then
+        STRICT_MODE="true"
+    fi
+
+    if [[ -z "${VAULT_ADDR}" || -z "${VAULT_TOKEN}" || -z "${VAULT_MAP}" ]]; then
+        echo "❌ 階段 ${STAGE} Vault 設定不完整（需要 ADDR/TOKEN/MAP）"
+        [[ "${STRICT_MODE}" == "true" ]] && return 1 || return 0
+    fi
+
+    echo "🔐 從 Vault 載入階段 ${STAGE} 的敏感環境變數..."
+
+    local HAS_ERROR=false
+    IFS=',' read -ra MAPPINGS <<< "${VAULT_MAP}"
+    for ITEM in "${MAPPINGS[@]}"; do
+        local ENTRY=$(echo "${ITEM}" | xargs)
+        [[ -z "${ENTRY}" ]] && continue
+
+        # 格式：ENV_NAME=secret/path#key
+        if [[ "${ENTRY}" != *=* || "${ENTRY}" != *#* ]]; then
+            echo "❌ 無效的 Vault mapping：${ENTRY}（需符合 ENV=path#key）"
+            HAS_ERROR=true
+            [[ "${STRICT_MODE}" == "true" ]] && break
+            continue
+        fi
+
+        local ENV_NAME="${ENTRY%%=*}"
+        local PATH_AND_KEY="${ENTRY#*=}"
+        local SECRET_PATH="${PATH_AND_KEY%#*}"
+        local SECRET_KEY="${PATH_AND_KEY##*#}"
+
+        if [[ -z "${ENV_NAME}" || -z "${SECRET_PATH}" || -z "${SECRET_KEY}" ]]; then
+            echo "❌ 無效的 Vault mapping：${ENTRY}"
+            HAS_ERROR=true
+            [[ "${STRICT_MODE}" == "true" ]] && break
+            continue
+        fi
+
+        local SECRET_VALUE
+        if ! SECRET_VALUE=$(fetch_vault_secret_value "${VAULT_ADDR}" "${VAULT_TOKEN}" "${SECRET_PATH}" "${SECRET_KEY}" "${VAULT_CACERT}"); then
+            echo "❌ 讀取 Vault 失敗：${SECRET_PATH}#${SECRET_KEY}"
+            HAS_ERROR=true
+            [[ "${STRICT_MODE}" == "true" ]] && break
+            continue
+        fi
+
+        # 僅輸出 key，不輸出 value，避免敏感資訊洩漏
+        printf 'export %s=%q\n' "${ENV_NAME}" "${SECRET_VALUE}" >> "${PIPELINE_ENV_FILE}"
+        echo "   ✅ 已注入：${ENV_NAME}"
+    done
+
+    if [[ "${HAS_ERROR}" == "true" && "${STRICT_MODE}" == "true" ]]; then
+        echo "❌ 階段 ${STAGE} Vault 注入失敗（strict 模式）"
+        return 1
+    fi
+
+    return 0
+}
+
 # 執行單一階段
 # 參數：
 #   $1 - 專案名稱
@@ -301,13 +458,20 @@ execute_stage() {
         return 0
     fi
     
-    # 載入上一階段的環境變數（如果存在 .pipeline.env）
+    # 在執行階段前，按需從 Vault 載入敏感環境變數到 .pipeline.env
     local PIPELINE_ENV_FILE="${PROJECT_PATH}/.pipeline.env"
+    inject_stage_env_from_vault "${STAGE}" "${PROJECT_PATH}"
+    local VAULT_INJECT_EXIT_CODE=$?
+    if [[ ${VAULT_INJECT_EXIT_CODE} -ne 0 ]]; then
+        return ${VAULT_INJECT_EXIT_CODE}
+    fi
+
+    # 載入上一階段（或 Vault 注入）的環境變數
     local LOAD_PIPELINE_ENV=""
     if [[ -f "${PIPELINE_ENV_FILE}" ]]; then
-        LOAD_PIPELINE_ENV="source .pipeline.env 2>/dev/null || true; "
+        LOAD_PIPELINE_ENV="source ${PIPELINE_ENV_FILE} 2>/dev/null || true; "
     fi
-    
+
     # 執行腳本
     exec_script_in_container_with_project ${PROJECT_NAME} ${IMAGE} "cd ${WORKDIR_ESCAPED} && ${LOAD_PIPELINE_ENV}./${SCRIPT}" ${STAGE}
     local EXIT_CODE=$?
@@ -608,6 +772,18 @@ show_pipeline_help() {
     echo "                    設定該階段只能透過 --manual 參數手動觸發（預設：false）"
     echo "  KDE_PIPELINE_STAGE_<stage>_ALLOW_FAILURE=true"
     echo "                    允許該階段失敗但不影響後續階段執行（預設：false）"
+    echo "  KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_ENABLED=true"
+    echo "                    啟用從 HashiCorp Vault 載入該階段環境變數"
+    echo "  KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_ADDR=..."
+    echo "                    Vault 位址（例如：https://vault.example.com）"
+    echo "  KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_TOKEN=..."
+    echo "                    Vault Token（建議放在 .env）"
+    echo "  KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_MAP=ENV=path#key,..."
+    echo "                    Secret 對應表（只注入 mapping 指定變數）"
+    echo "  KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_CACERT=/path/to/ca.pem"
+    echo "                    自簽 CA 憑證路徑（可選）"
+    echo "  KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_STRICT=true"
+    echo "                    strict 模式（預設：true，注入失敗即中止階段）"
     echo ""
     echo "注意："
     echo "  - 所有選項都從命令行參數讀取，不會從環境變數繼承"

--- a/scripts/utils/pipeline.sh
+++ b/scripts/utils/pipeline.sh
@@ -289,7 +289,7 @@ fetch_vault_secret_value() {
     fi
 
     # 使用 tools image 啟動一次性容器解析 JSON，結束即刪除（docker run --rm -i）
-    local TOOLS_IMAGE="${KDE_TOOLS_IMAGE:-r82wei/tools:1.0.0}"
+    local TOOLS_IMAGE="${KDE_TOOLS_IMAGE:-r82wei/kde-cli/tools:1.0.0}"
     local VALUE
     if ! VALUE=$(printf '%s' "${RESPONSE}" | docker run --rm -i -e SECRET_KEY="${SECRET_KEY}" "${TOOLS_IMAGE}" jq -er --arg key "${SECRET_KEY}" '.data.data[$key] // .data[$key]' 2>/dev/null); then
         return 4


### PR DESCRIPTION
## Summary
- add stage-level Vault secret injection for pipeline execution
- support mapping format `ENV_NAME=secret/path#key` to avoid full secret import
- support optional custom CA cert for Vault TLS
- default strict mode (fail stage when Vault injection fails)
- update CI/CD pipeline docs with configuration examples

## New env vars
- `KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_ENABLED`
- `KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_ADDR`
- `KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_TOKEN`
- `KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_CACERT` (optional)
- `KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_MAP`
- `KDE_PIPELINE_STAGE_<stage>_ENV_FROM_VAULT_STRICT` (default: `true`)

## Behavior
- when enabled, pipeline fetches mapped secrets from Vault before stage execution
- fetched values are written into `.pipeline.env` as exported variables
- stage script then loads `.pipeline.env` automatically
- logs only print variable names, never secret values

Resolves #37
